### PR TITLE
Add injectable platform support for macOS

### DIFF
--- a/Sources/SignHereLibrary/Commands/CreateProvisioningProfileCommand.swift
+++ b/Sources/SignHereLibrary/Commands/CreateProvisioningProfileCommand.swift
@@ -120,6 +120,7 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
         case opensslPath = "opensslPath"
         case intermediaryAppleCertificates = "intermediaryAppleCertificates"
         case certificateSigningRequestSubject = "certificateSigningRequestSubject"
+        case platform = "platform"
     }
 
     @Option(help: "The key identifier of the private key (https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests)")
@@ -145,6 +146,9 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
 
     @Option(help: "The bundle identifier name for the desired bundle identifier, this is optional but if it is not set the logic will select the first bundle id it finds that matches `--bundle-identifier`")
     internal var bundleIdentifierName: String?
+
+    @Option(help: "The platform to filter bundle identifiers for")
+    internal var platform: Platform
 
     @Option(help: "The profile type which you wish to create (https://developer.apple.com/documentation/appstoreconnectapi/profilecreaterequest/data/attributes)")
     internal var profileType: String
@@ -218,7 +222,8 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
         opensslPath: String,
         intermediaryAppleCertificates: [String],
         certificateSigningRequestSubject: String,
-        bundleIdentifierName: String?
+        bundleIdentifierName: String?,
+        platform: Platform
     ) {
         self.files = files
         self.log = log
@@ -240,6 +245,7 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
         self.intermediaryAppleCertificates = intermediaryAppleCertificates
         self.certificateSigningRequestSubject = certificateSigningRequestSubject
         self.bundleIdentifierName = bundleIdentifierName
+        self.platform = platform
     }
 
     internal init(from decoder: Decoder) throws {
@@ -272,7 +278,8 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
             opensslPath: try container.decode(String.self, forKey: .opensslPath),
             intermediaryAppleCertificates: try container.decodeIfPresent([String].self, forKey: .intermediaryAppleCertificates) ?? [],
             certificateSigningRequestSubject: try container.decode(String.self, forKey: .certificateSigningRequestSubject),
-            bundleIdentifierName: try container.decodeIfPresent(String.self, forKey: .bundleIdentifierName)
+            bundleIdentifierName: try container.decodeIfPresent(String.self, forKey: .bundleIdentifierName),
+            platform: try container.decode(Platform.self, forKey: .platform)
         )
     }
 
@@ -303,7 +310,8 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
             bundleId: try iTunesConnectService.determineBundleIdITCId(
                 jsonWebToken: jsonWebToken,
                 bundleIdentifier: bundleIdentifier,
-                bundleIdentifierName: bundleIdentifierName
+                bundleIdentifierName: bundleIdentifierName,
+                platform: platform
             ),
             certificateId: certificateId,
             deviceIDs: deviceIDs,

--- a/Sources/SignHereLibrary/Models/Platform.swift
+++ b/Sources/SignHereLibrary/Models/Platform.swift
@@ -1,0 +1,14 @@
+//
+//  Platform.swift
+//  Models
+//
+//  Created by Caleb Davis on 06/07/23.
+//
+
+import ArgumentParser
+import Foundation
+
+enum Platform: String, Decodable, ExpressibleByArgument {
+    case iOS = "IOS"
+    case macOS = "MAC_OS"
+}

--- a/Sources/SignHereLibrary/Services/iTunesConnectService.swift
+++ b/Sources/SignHereLibrary/Services/iTunesConnectService.swift
@@ -26,7 +26,8 @@ internal protocol iTunesConnectService {
     func determineBundleIdITCId(
         jsonWebToken: String,
         bundleIdentifier: String,
-        bundleIdentifierName: String?
+        bundleIdentifierName: String?,
+        platform: Platform
     ) throws -> String
     func fetchITCDeviceIDs(jsonWebToken: String) throws -> Set<String>
     func createProfile(
@@ -226,7 +227,8 @@ internal class iTunesConnectServiceImp: iTunesConnectService {
     func determineBundleIdITCId(
         jsonWebToken: String,
         bundleIdentifier: String,
-        bundleIdentifierName: String?
+        bundleIdentifierName: String?,
+        platform: Platform
     ) throws -> String {
         var urlComponents: URLComponents = .init()
         urlComponents.scheme = Constants.httpsScheme
@@ -234,7 +236,7 @@ internal class iTunesConnectServiceImp: iTunesConnectService {
         urlComponents.path = "/v1/bundleIds"
         urlComponents.queryItems = [
             .init(name: "filter[identifier]", value: bundleIdentifier),
-            .init(name: "filter[platform]", value: "IOS"),
+            .init(name: "filter[platform]", value: platform.rawValue),
             .init(name: "limit", value: "200")
         ]
         guard let url: URL = urlComponents.url

--- a/Tests/SignHereLibraryTests/CreateProvisioningProfileCommandTests.swift
+++ b/Tests/SignHereLibraryTests/CreateProvisioningProfileCommandTests.swift
@@ -158,7 +158,8 @@ final class CreateProvisioningProfileCommandTests: XCTestCase {
             "outputPath": "/outputPath",
             "opensslPath": "/opensslPath",
             "certificateSigningRequestSubject": "certificateSigningRequestSubject",
-            "bundleIdentifierName": "bundleIdentifierName"
+            "bundleIdentifierName": "bundleIdentifierName",
+            "platform": "IOS"
         }
         """.utf8)
 
@@ -177,6 +178,7 @@ final class CreateProvisioningProfileCommandTests: XCTestCase {
         XCTAssertEqual(subject.certificateType, "certificateType")
         XCTAssertEqual(subject.outputPath, "/outputPath")
         XCTAssertEqual(subject.bundleIdentifierName, "bundleIdentifierName")
+        XCTAssertEqual(subject.platform, .iOS)
     }
 
     func test_execute_alreadyActiveCertificate() throws {

--- a/Tests/SignHereLibraryTests/CreateProvisioningProfileCommandTests.swift
+++ b/Tests/SignHereLibraryTests/CreateProvisioningProfileCommandTests.swift
@@ -55,7 +55,8 @@ final class CreateProvisioningProfileCommandTests: XCTestCase {
             opensslPath: "/opensslPath",
             intermediaryAppleCertificates: ["/intermediaryAppleCertificate"],
             certificateSigningRequestSubject: "certificateSigningRequestSubject",
-            bundleIdentifierName: "bundleIdentifierName"
+            bundleIdentifierName: "bundleIdentifierName",
+            platform: .iOS
         )
     }
 

--- a/Tests/SignHereLibraryTests/PlatformTests.swift
+++ b/Tests/SignHereLibraryTests/PlatformTests.swift
@@ -1,0 +1,9 @@
+import Foundation
+import XCTestCase
+
+final class PlatformTests: XCTestCase {
+    func test_rawValue() {
+        XCTAssertEqual(Platform.iOS.rawValue, "IOS")
+        XCTAssertEqual(Platform.macOS.rawValue, "MAC_OS")
+    }
+}

--- a/Tests/SignHereLibraryTests/PlatformTests.swift
+++ b/Tests/SignHereLibraryTests/PlatformTests.swift
@@ -1,5 +1,12 @@
-import Foundation
-import XCTestCase
+//
+//  PlatformTests.swift
+//  SignHereLibraryTests
+//
+//  Created by Caleb Davis on 06/21/2023.
+//
+
+@testable import SignHereLibrary
+import XCTest
 
 final class PlatformTests: XCTestCase {
     func test_rawValue() {

--- a/Tests/SignHereLibraryTests/iTunesConnectServiceTests.swift
+++ b/Tests/SignHereLibraryTests/iTunesConnectServiceTests.swift
@@ -383,7 +383,8 @@ final class iTunesConnectServiceTests: XCTestCase {
         let value: String = try subject.determineBundleIdITCId(
             jsonWebToken: "jsonWebToken",
             bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: nil
+            bundleIdentifierName: nil,
+            platform: .iOS
         )
 
         // THEN
@@ -407,7 +408,8 @@ final class iTunesConnectServiceTests: XCTestCase {
         let value: String = try subject.determineBundleIdITCId(
             jsonWebToken: "jsonWebToken",
             bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: "name"
+            bundleIdentifierName: "name",
+            platform: .iOS
         )
 
         // THEN
@@ -431,7 +433,8 @@ final class iTunesConnectServiceTests: XCTestCase {
         XCTAssertThrowsError(try subject.determineBundleIdITCId(
             jsonWebToken: "jsonWebToken",
             bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: "invalid"
+            bundleIdentifierName: "invalid",
+            platform: .iOS
         )) {
             if case iTunesConnectServiceImp.Error.unableToDetermineITCIdForBundleId = $0 {
                 return
@@ -458,7 +461,8 @@ final class iTunesConnectServiceTests: XCTestCase {
         XCTAssertThrowsError(try subject.determineBundleIdITCId(
             jsonWebToken: "jsonWebToken",
             bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: nil
+            bundleIdentifierName: nil,
+            platform: .iOS
         )) {
             if case iTunesConnectServiceImp.Error.unableToDecodeResponse = $0 {
                 return


### PR DESCRIPTION
Injecting the platform to add support for macOS in the `filter[platform]` query param.

### Note
This field supports an array of Strings so we could potentially extend `sign-here` to support more than one platform at a time. 

<img width="1052" alt="Screenshot 2023-06-07 at 2 45 09 PM" src="https://github.com/Tinder/sign-here/assets/65983433/0e885443-42f0-4eca-ab75-dbf7d0abcc2c">
