### PR TITLE
Add Platform Option

### DIFF
--- a/Sources/SignHereLibrary/Commands/CreateProvisioningProfileCommand.swift
+++ b/Sources/SignHereLibrary/Commands/CreateProvisioningProfileCommand.swift
@@ -114,6 +114,7 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
         case keychainPassword = "keychainPassword"
         case bundleIdentifier = "bundleIdentifier"
         case bundleIdentifierName = "bundleIdentifierName"
+        case platform = "platform"
         case profileType = "profileType"
         case certificateType = "certificateType"
         case outputPath = "outputPath"
@@ -145,6 +146,9 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
 
     @Option(help: "The bundle identifier name for the desired bundle identifier, this is optional but if it is not set the logic will select the first bundle id it finds that matches `--bundle-identifier`")
     internal var bundleIdentifierName: String?
+
+    @Option(help: "The intended operating system for the target (https://developer.apple.com/documentation/appstoreconnectapi/bundleidplatform)")
+    internal var platform: String
 
     @Option(help: "The profile type which you wish to create (https://developer.apple.com/documentation/appstoreconnectapi/profilecreaterequest/data/attributes)")
     internal var profileType: String
@@ -218,7 +222,8 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
         opensslPath: String,
         intermediaryAppleCertificates: [String],
         certificateSigningRequestSubject: String,
-        bundleIdentifierName: String?
+        bundleIdentifierName: String?,
+        platform: String
     ) {
         self.files = files
         self.log = log
@@ -240,6 +245,7 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
         self.intermediaryAppleCertificates = intermediaryAppleCertificates
         self.certificateSigningRequestSubject = certificateSigningRequestSubject
         self.bundleIdentifierName = bundleIdentifierName
+        self.platform = platform
     }
 
     internal init(from decoder: Decoder) throws {
@@ -272,7 +278,8 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
             opensslPath: try container.decode(String.self, forKey: .opensslPath),
             intermediaryAppleCertificates: try container.decodeIfPresent([String].self, forKey: .intermediaryAppleCertificates) ?? [],
             certificateSigningRequestSubject: try container.decode(String.self, forKey: .certificateSigningRequestSubject),
-            bundleIdentifierName: try container.decodeIfPresent(String.self, forKey: .bundleIdentifierName)
+            bundleIdentifierName: try container.decodeIfPresent(String.self, forKey: .bundleIdentifierName),
+            platform: try container.decode(String.self, forKey: .platform)
         )
     }
 
@@ -303,7 +310,8 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
             bundleId: try iTunesConnectService.determineBundleIdITCId(
                 jsonWebToken: jsonWebToken,
                 bundleIdentifier: bundleIdentifier,
-                bundleIdentifierName: bundleIdentifierName
+                bundleIdentifierName: bundleIdentifierName,
+                platform: platform
             ),
             certificateId: certificateId,
             deviceIDs: deviceIDs,

--- a/Tests/SignHereLibraryTests/CreateProvisioningProfileCommandTests.swift
+++ b/Tests/SignHereLibraryTests/CreateProvisioningProfileCommandTests.swift
@@ -55,7 +55,8 @@ final class CreateProvisioningProfileCommandTests: XCTestCase {
             opensslPath: "/opensslPath",
             intermediaryAppleCertificates: ["/intermediaryAppleCertificate"],
             certificateSigningRequestSubject: "certificateSigningRequestSubject",
-            bundleIdentifierName: "bundleIdentifierName"
+            bundleIdentifierName: "bundleIdentifierName",
+            platform: "platform"
         )
         isRecording = false
     }
@@ -158,7 +159,8 @@ final class CreateProvisioningProfileCommandTests: XCTestCase {
             "outputPath": "/outputPath",
             "opensslPath": "/opensslPath",
             "certificateSigningRequestSubject": "certificateSigningRequestSubject",
-            "bundleIdentifierName": "bundleIdentifierName"
+            "bundleIdentifierName": "bundleIdentifierName",
+            "platform": "platform"
         }
         """.utf8)
 
@@ -177,6 +179,7 @@ final class CreateProvisioningProfileCommandTests: XCTestCase {
         XCTAssertEqual(subject.certificateType, "certificateType")
         XCTAssertEqual(subject.outputPath, "/outputPath")
         XCTAssertEqual(subject.bundleIdentifierName, "bundleIdentifierName")
+        XCTAssertEqual(subject.platform, "platform")
     }
 
     func test_execute_alreadyActiveCertificate() throws {

--- a/Tests/SignHereLibraryTests/__Snapshots__/iTunesConnectServiceTests/iTunesConnectServiceTests_testErrors.1.txt
+++ b/Tests/SignHereLibraryTests/__Snapshots__/iTunesConnectServiceTests/iTunesConnectServiceTests_testErrors.1.txt
@@ -1,2 +1,3 @@
 [iTunesConnectServiceImp] Unable to determine iTunesConnect API ID for bundle identifier
 - Bundle Identifier: bundleIdentifier
+- Platform: platform

--- a/Tests/SignHereLibraryTests/iTunesConnectServiceTests.swift
+++ b/Tests/SignHereLibraryTests/iTunesConnectServiceTests.swift
@@ -60,7 +60,8 @@ final class iTunesConnectServiceTests: XCTestCase {
     func testErrors() {
         assertSnapshot(
             matching: iTunesConnectServiceImp.Error.unableToDetermineITCIdForBundleId(
-                bundleIdentifier: "bundleIdentifier"
+                bundleIdentifier: "bundleIdentifier",
+                platform: "platform"
             ).description,
             as: .lines
         )
@@ -383,7 +384,8 @@ final class iTunesConnectServiceTests: XCTestCase {
         let value: String = try subject.determineBundleIdITCId(
             jsonWebToken: "jsonWebToken",
             bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: nil
+            bundleIdentifierName: nil,
+            platform: "platform"
         )
 
         // THEN
@@ -407,7 +409,8 @@ final class iTunesConnectServiceTests: XCTestCase {
         let value: String = try subject.determineBundleIdITCId(
             jsonWebToken: "jsonWebToken",
             bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: "name"
+            bundleIdentifierName: "name",
+            platform: "platform"
         )
 
         // THEN
@@ -428,11 +431,14 @@ final class iTunesConnectServiceTests: XCTestCase {
         }
 
         // WHEN
-        XCTAssertThrowsError(try subject.determineBundleIdITCId(
-            jsonWebToken: "jsonWebToken",
-            bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: "invalid"
-        )) {
+        XCTAssertThrowsError(
+            try subject.determineBundleIdITCId(
+                jsonWebToken: "jsonWebToken",
+                bundleIdentifier: "bundleIdentifier",
+                bundleIdentifierName: "invalid",
+                platform: "platform"
+            )
+        ) {
             if case iTunesConnectServiceImp.Error.unableToDetermineITCIdForBundleId = $0 {
                 return
             }
@@ -455,11 +461,14 @@ final class iTunesConnectServiceTests: XCTestCase {
         }
 
         // WHEN
-        XCTAssertThrowsError(try subject.determineBundleIdITCId(
-            jsonWebToken: "jsonWebToken",
-            bundleIdentifier: "bundleIdentifier",
-            bundleIdentifierName: nil
-        )) {
+        XCTAssertThrowsError(
+            try subject.determineBundleIdITCId(
+                jsonWebToken: "jsonWebToken",
+                bundleIdentifier: "bundleIdentifier",
+                bundleIdentifierName: nil,
+                platform: "platform"
+            )
+        ) {
             if case iTunesConnectServiceImp.Error.unableToDecodeResponse = $0 {
                 return
             }
@@ -757,7 +766,7 @@ final class iTunesConnectServiceTests: XCTestCase {
                     attributes: ListBundleIDsResponse.BundleId.Attributes(
                         name: "name",
                         identifier: "bundleIdentifier",
-                        platform: "IOS"
+                        platform: "platform"
                     )
                 )
             ]


### PR DESCRIPTION
### Description

Add explicit `platform` option to `CreateProvisioningProfileCommand`, to enable consumers to inject the intended platform type for their underlying targets.

### Changelog
- IMPROVED:
    - `iTunesConnectService.determineBundleIdITCId(...)` with `platform` parameter
    - `CreateProvisioningProfileCommand` with `platform` option
- FIXED:
    - Tests