### PR TITLE
Remove swift.treat_warnings_as_errors for swift_library targets that suppress warnings

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -47,6 +47,9 @@ swift_library(
     copts = [
         "-suppress-warnings",
     ],
+    features = [
+        "-swift.treat_warnings_as_errors",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         ":ArgumentParserToolInfo"
@@ -73,6 +76,9 @@ swift_library(
     copts = [
         "-suppress-warnings",
     ],
+    features = [
+        "-swift.treat_warnings_as_errors",
+    ],
     visibility = ["//visibility:public"],
 )
         """,
@@ -92,7 +98,12 @@ swift_library(
     srcs = glob([
         "Sources/CryptorECC/**/*.swift",
     ]),
-    copts = ["-suppress-warnings"],
+    copts = [
+        "-suppress-warnings",
+    ],
+    features = [
+        "-swift.treat_warnings_as_errors",
+    ],
     module_name = "CryptorECC",
     visibility = [
         "//visibility:public",


### PR DESCRIPTION
`-suppress-warnings` and `-warnings-as-errors` are conflicting flags that will result in a build error.

Since these libraries are having their warnings suppressed, this makes sure that a build config with `--features=swift.treat_warnings_as_errors` does not propegate down to these `swift_library` targets.