### PR TITLE
Add `integrity` to mockolo

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -107,6 +107,7 @@ swift_library(
     _maybe(
         http_archive,
         name = "mockolo",
+        integrity = "sha256-12D/tUZKP87bS2NyfmdJP/pFg/JmsdFv1xsr0BvKUGs=",
         build_file_content = """
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_binary", "swift_library")
 
@@ -153,7 +154,6 @@ swift_binary(
     ],
 )
         """,
-        sha256 = "",
         strip_prefix = "mockolo-%s" % MOCKOLO_VERSION,
         urls = ["https://github.com/uber/mockolo/archive/%s.zip" % MOCKOLO_VERSION],
     )


### PR DESCRIPTION
This was missing