### PR TITLE
Added new keychain path log

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1379,7 +1379,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%non_module_dependencies": {
       "general": {
-        "bzlTransitiveDigest": "P1JUpq+Gnkii3uIYNOJ8g2c/SfGD8pMGSizap66ROpo=",
+        "bzlTransitiveDigest": "Ep7fmfOBPzREF045u058BTSSHGEnXMIpN7hhvedcJHw=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1585,7 +1585,7 @@
     },
     "@@rules_java~//java:extensions.bzl%toolchains": {
       "general": {
-        "bzlTransitiveDigest": "tJHbmWnq7m+9eUBnUdv7jZziQ26FmcGL9C5/hU3Q9UQ=",
+        "bzlTransitiveDigest": "0N5b5J9fUzo0sgvH4F3kIEaeXunz4Wy2/UtSFV/eXUY=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -2090,7 +2090,7 @@
     },
     "@@rules_swift~//swift:extensions.bzl%non_module_deps": {
       "general": {
-        "bzlTransitiveDigest": "m78FIsmmvFalZmXxi26P0AW5U6W6G+u5KGknjClFU/0=",
+        "bzlTransitiveDigest": "2HjojbikzYbmbwZ2N19uSSpcNJ002txg/QLUMC0rEYk=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_testErrors.4.txt
+++ b/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_testErrors.4.txt
@@ -1,0 +1,3 @@
+[CreateKeychainCommand] Unable to list keychains
+- Output: output
+- Error: errorOutput

--- a/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_testErrors.5.txt
+++ b/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_testErrors.5.txt
@@ -1,0 +1,4 @@
+[CreateKeychainCommand] Unable to find keychain
+- Keychain Name: keychainName
+- Output: output
+- Error: errorOutput

--- a/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_test_execute_cannotFindKeychain.1.txt
+++ b/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_test_execute_cannotFindKeychain.1.txt
@@ -1,0 +1,39 @@
+▿ 4 elements
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 5 elements
+      - "security"
+      - "create-keychain"
+      - "-p"
+      - "keychainPassword"
+      - "keychainName"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 6 elements
+      - "security"
+      - "set-keychain-settings"
+      - "-t"
+      - "7200"
+      - "-l"
+      - "keychainName"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 5 elements
+      - "security"
+      - "unlock-keychain"
+      - "-p"
+      - "keychainPassword"
+      - "keychainName"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 2 elements
+      - "security"
+      - "list-keychains"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none

--- a/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_test_execute_cannotListKeychain.1.txt
+++ b/Tests/SignHereLibraryTests/__Snapshots__/CreateKeychainCommandTests/CreateKeychainCommandTests_test_execute_cannotListKeychain.1.txt
@@ -1,0 +1,39 @@
+▿ 4 elements
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 5 elements
+      - "security"
+      - "create-keychain"
+      - "-p"
+      - "keychainPassword"
+      - "keychainName"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 6 elements
+      - "security"
+      - "set-keychain-settings"
+      - "-t"
+      - "7200"
+      - "-l"
+      - "keychainName"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 5 elements
+      - "security"
+      - "unlock-keychain"
+      - "-p"
+      - "keychainPassword"
+      - "keychainName"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none
+  ▿ (4 elements)
+    - .0: "/usr/bin/env"
+    ▿ .1: 2 elements
+      - "security"
+      - "list-keychains"
+    - .2: Optional<Dictionary<String, String>>.none
+    - .3: Optional<Data>.none


### PR DESCRIPTION
This pull request adds a log after the keychain is created:
```
INFO: Running command line: bazel-bin/Sources/SignHereTool/sign-here create-keychain --keychain-name TestKeychain --keychain-password ***
Keychain created in the path: /Users/omarzl/Library/Keychains/TestKeychain-db
```

This small change can add these improvements:
- There is a log that confirms to the user that the keychain was created
- It is a sanity check that guarantees that they keychain was created by calling `security list-keychains`

Added tests for the new error types:
```
bazel test //Tests/...
//Tests/SignHereLibraryTests:SignHereUnitTests                  (cached) PASSED in 0.6s
    PASSED  .Tests/SignHereLibraryTests/SignHereUnitTests.test-runner.sh (0.0s)
Test cases: finished with 1 passing and 0 failing out of 1 test cases
```
