### PR TITLE
removes a validation to consider universal bundle ids

### DIFF
--- a/Sources/SignHereLibrary/Services/iTunesConnectService.swift
+++ b/Sources/SignHereLibrary/Services/iTunesConnectService.swift
@@ -268,8 +268,7 @@ internal class iTunesConnectServiceImp: iTunesConnectService {
         do {
             let listBundleIDsResponse: ListBundleIDsResponse = try createITCApiJSONDecoder().decode(ListBundleIDsResponse.self, from: data)
             guard let bundleIdITCId: String = listBundleIDsResponse.data.compactMap({ bundleData in
-                guard bundleData.attributes.identifier == bundleIdentifier,
-                    bundleData.attributes.platform == platform
+                guard bundleData.attributes.identifier == bundleIdentifier
                 else {
                     return nil
                 }


### PR DESCRIPTION
Hello! I am setting up an example workflow with `sign-in` tool 😄 

While creating a new provisioning profile I had this error:

```
Error: [iTunesConnectServiceImp] Unable to determine iTunesConnect API ID for bundle identifier
- Bundle Identifier: com.omarzl.bazel.sample
- Platform: IOS
```

I added a print for `listBundleIDsResponse.data` and I found out that the bundle id has the platform type UNIVERSAL 🤯:

`[SignHereLibrary.ListBundleIDsResponse.BundleId(id: "XXXX", type: "bundleIds", attributes: SignHereLibrary.ListBundleIDsResponse.BundleId.Attributes(name: "Bazel Sample", identifier: "com.omarzl.bazel.sample", platform: "UNIVERSAL"))]`

I temporary removed the queryItems in the request to list all my bundle ids and I found out that I have these 3 types: IOS, MAC_OS and UNIVERSAL.

I went to ASC and I discovered that it doesn't allow you to select the platform, it automatically sets all of them. So my guess is that all new bundle ids are now UNIVERSAL, and old ones still preserve the IOS/MAC_OS types 🤔 

<img width="408" alt="Screenshot 2024-05-23 at 16 16 52" src="https://github.com/Tinder/sign-here/assets/6267487/3de558e1-a88d-4768-b6eb-8aae56873ca1">

Fix:
Since the network call already has a constraint in the platform filter (`Sources/SignHereLibrary/Services/iTunesConnectService.swift:241`):
```
.init(name: "filter[platform]", value: "IOS")
```

I think that the best solution could be to remove this validation to support these UNIVERSAL bundle ids.

After removing this line, the provisioning profile was created 🎉 