### PR TITLE
improved docs related to the private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ OPTIONS:
                           The path to a private key to use for generating PEM
                           and P12 files. This key will be attached to any
                           generated certificates or profiles
+                          Use `openssl genrsa -out key.pem 2048` to generate it
   --itunes-connect-key-path <itunes-connect-key-path>
                           The path to the private key
                           (https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests)

--- a/Sources/SignHereLibrary/Commands/CreateProvisioningProfileCommand.swift
+++ b/Sources/SignHereLibrary/Commands/CreateProvisioningProfileCommand.swift
@@ -130,7 +130,7 @@ internal struct CreateProvisioningProfileCommand: ParsableCommand {
     @Option(help: "The issuer id of the private key (https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests)")
     internal var issuerID: String
 
-    @Option(help: "The path to a private key to use for generating PEM and P12 files. This key will be attached to any generated certificates or profiles")
+    @Option(help: "The path to a private key to use for generating PEM and P12 files. This key will be attached to any generated certificates or profiles. Use `openssl genrsa -out key.pem 2048` to generate it.")
     internal var privateKeyPath: String
 
     @Option(help: "The path to the private key (https://developer.apple.com/documentation/appstoreconnectapi/generating_tokens_for_api_requests)")


### PR DESCRIPTION
I struggled a little bit understanding what I should use in the arg `--private-key-path` while creating a provisioning profile
I am used to let Keychain Assistant to create the key pair and the CSR 😄

So this pr aims to improve the docs regarding the priv key. Do you consider it is the right place to include this command example?

Also are you using the same command `openssl genrsa -out key.pem 2048`? Or do you suggest another one.


Thanks!